### PR TITLE
renaming grpc sdk to proto

### DIFF
--- a/.pandaci/echo.workflow.ts
+++ b/.pandaci/echo.workflow.ts
@@ -1,5 +1,0 @@
-import { $, docker, job } from "@pandaci/workflow";
-
-docker("ubuntu:latest", () => {
-  $`echo "Hello, World!"`;
-});

--- a/proto/ts/README.md
+++ b/proto/ts/README.md
@@ -1,4 +1,4 @@
-# @pandaci/grpc
+# @pandaci/proto
 
 Generated grpc code for pandaci. This package is used by @pandaci/workflow.
 

--- a/sdks/ts/api.ts
+++ b/sdks/ts/api.ts
@@ -1,4 +1,4 @@
-import { WorkflowService } from "@pandaci/grpc";
+import { WorkflowService } from "@pandaci/proto";
 import {
   type Client,
   createClient,

--- a/sdks/ts/context.ts
+++ b/sdks/ts/context.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { JobMeta, TaskMeta } from "@pandaci/grpc";
+import type { JobMeta, TaskMeta } from "@pandaci/proto";
 
 export interface JobContext {
   meta: JobMeta;

--- a/sdks/ts/docker/dockerPromise.ts
+++ b/sdks/ts/docker/dockerPromise.ts
@@ -3,7 +3,7 @@ import {
   StartTaskData_Docker_DockerVolume_Type,
   type TaskMeta,
   WorkflowAlert_Type,
-} from "@pandaci/grpc";
+} from "@pandaci/proto";
 import type {
   DockerTaskFn,
   DockerTaskOptions,

--- a/sdks/ts/docker/dockerTypes.ts
+++ b/sdks/ts/docker/dockerTypes.ts
@@ -1,4 +1,4 @@
-import type { Conclusion } from "@pandaci/grpc";
+import type { Conclusion } from "@pandaci/proto";
 import type { Volume } from "../volume.ts";
 
 export interface DockerTaskOptions {

--- a/sdks/ts/job/jobPromise.ts
+++ b/sdks/ts/job/jobPromise.ts
@@ -1,4 +1,4 @@
-import { Conclusion, WorkflowAlert_Type } from "@pandaci/grpc";
+import { Conclusion, WorkflowAlert_Type } from "@pandaci/proto";
 import type { JobOptions, JobResult } from "./jobTypes.ts";
 import { setImmediate } from "node:timers";
 import { jobContext } from "../context.ts";

--- a/sdks/ts/job/jobTypes.ts
+++ b/sdks/ts/job/jobTypes.ts
@@ -1,4 +1,4 @@
-import type { Conclusion } from "@pandaci/grpc";
+import type { Conclusion } from "@pandaci/proto";
 import type { JobPromise } from "./jobPromise.ts";
 
 export type JobFn = (() => void) | (() => Promise<void>);

--- a/sdks/ts/shell/execPromise.ts
+++ b/sdks/ts/shell/execPromise.ts
@@ -1,4 +1,4 @@
-import { WorkflowAlert_Type } from "@pandaci/grpc";
+import { WorkflowAlert_Type } from "@pandaci/proto";
 import type { JobContext, TaskContext } from "../context.ts";
 import { setImmediate } from "node:timers";
 import { getWorkflowClient } from "../api.ts";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the project documentation header to reflect the new package identifier, shifting the focus from a gRPC-specific context to a broader proto context.
  
- **Refactor**
  - Revised module references and import sources across the project for consistent naming.
  - Removed an obsolete workflow definition that was no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->