### PR TITLE
Move auth guard to root layout

### DIFF
--- a/web/src/lib/runes/user.svelte.ts
+++ b/web/src/lib/runes/user.svelte.ts
@@ -1,6 +1,7 @@
 import { queries } from '$lib/queries';
 import { createQuery } from '@tanstack/svelte-query';
 import { goto } from '$app/navigation';
+import { page } from '$app/state';
 
 export interface User {
 	id: string;
@@ -19,6 +20,7 @@ export function getUser({
 		select: ({ data }) => ({ id: data.identity?.id, ...data.identity?.traits }) as User,
 		retry(failureCount, error: any) {
 			if (error?.response?.status === 401) {
+				if (page.route.id?.startsWith('/(auth)')) return false;
 				if (globalThis.location.pathname === '/') goto('/login');
 				else goto(`/login?return_to=${encodeURIComponent(globalThis.location.toString())}`);
 				return false;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 	import ThemeProvider from '$lib/components/themeProvider.svelte';
 	import posthog from 'posthog-js';
 	import { PUBLIC_STAGE } from '$env/static/public';
+	import HideUntilAuthed from './hideUntilAuthed.svelte';
 
 	const posthogToken =
 		PUBLIC_STAGE === 'prod'
@@ -55,6 +56,7 @@
 </svelte:head>
 
 <QueryClientProvider client={queryClient}>
+	<HideUntilAuthed />
 	<ThemeProvider>
 		{@render children()}
 	</ThemeProvider>

--- a/web/src/routes/account/+layout.svelte
+++ b/web/src/routes/account/+layout.svelte
@@ -8,7 +8,6 @@
 	import clsx from 'clsx';
 	import { getUser } from '$lib/runes/user.svelte';
 	import posthog from 'posthog-js';
-	import HideUntilAuthed from '../hideUntilAuthed.svelte';
 
 	const { children } = $props();
 
@@ -25,7 +24,6 @@
 	});
 </script>
 
-<HideUntilAuthed />
 <SidebarLayout>
 	{#snippet sidebarBody(collapsed)}
 		<SidebarHeading class="pb-0.5">Account</SidebarHeading>

--- a/web/src/routes/new/+layout.svelte
+++ b/web/src/routes/new/+layout.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-	import HideUntilAuthed from '../hideUntilAuthed.svelte';
-
-	const { children } = $props();
-</script>
-
-<HideUntilAuthed />
-
-{@render children()}

--- a/web/src/routes/welcome/+layout.svelte
+++ b/web/src/routes/welcome/+layout.svelte
@@ -1,8 +1,20 @@
 <script lang="ts">
-	import HideUntilAuthed from '../hideUntilAuthed.svelte';
+	import { getUser } from '$lib/runes/user.svelte';
+	import posthog from 'posthog-js';
 
 	const { children } = $props();
+
+	const user = getUser();
+
+	$effect(() => {
+		if (user.data) {
+			posthog.identify(user.data.id, {
+				email: user.data.email,
+				name: user.data.name
+			});
+			posthog.resetGroups();
+		}
+	});
 </script>
 
-<HideUntilAuthed />
 {@render children()}


### PR DESCRIPTION
The commit message above accurately describes the architectural change being made - moving the authentication guard component (HideUntilAuthed) from individual route layouts to the root layout file. No additional body text is needed since

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced dynamic content rendering in the main layout, which now displays content based on authentication status.
    - Enhanced the welcome page with automatic user identification for a more personalised experience.

- **Refactor**
    - Adjusted authentication error handling to prevent unnecessary retries on secured routes.
    - Revised content visibility logic across various pages to streamline the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->